### PR TITLE
Implement Issue #5: Revamp export formats to Markdown-KV and XML

### DIFF
--- a/src/ClipboardDialog.html
+++ b/src/ClipboardDialog.html
@@ -34,7 +34,7 @@
       
       .preview {
         width: 100%;
-        height: 150px;
+        height: 250px;
         font-family: 'Courier New', monospace;
         font-size: 11px;
         padding: 10px;
@@ -82,7 +82,7 @@
   <body>
     <div class="container">
       <div class="message">
-        Ready to copy <strong><?= dataType ?></strong> as JSON to clipboard.
+        Ready to copy <strong><?= dataType ?></strong> to clipboard.
       </div>
       
       <div class="success" id="successMessage">
@@ -90,7 +90,7 @@
       </div>
       
       <div class="preview-container">
-        <textarea class="preview" id="jsonPreview" readonly><?= jsonData ?></textarea>
+        <textarea class="preview" id="dataPreview" readonly><?= jsonData ?></textarea>
       </div>
       
       <div class="button-container">
@@ -105,7 +105,7 @@
 
     <script>
       function copyToClipboard() {
-        const textarea = document.getElementById('jsonPreview');
+        const textarea = document.getElementById('dataPreview');
         textarea.select();
         
         try {
@@ -156,7 +156,7 @@
       
       // Auto-select text on load for easy manual copying if needed
       window.onload = function() {
-        document.getElementById('jsonPreview').focus();
+        document.getElementById('dataPreview').focus();
       };
     </script>
   </body>

--- a/src/Code.gs
+++ b/src/Code.gs
@@ -11,147 +11,397 @@ function onInstall(e) {
 function onOpen(e) {
   const ui = SpreadsheetApp.getUi();
   ui.createAddonMenu()
-    .addItem('Copy Values (JSON)', 'exportValuesJSON')
-    .addItem('Copy Formulas (JSON)', 'exportFormulasJSON')
-    .addItem('Copy Both (JSON)', 'exportBothJSON')
+    .addItem('Export Rows (Markdown)', 'exportRowBasedMarkdown')
+    .addItem('Export Columns (Markdown)', 'exportColumnBasedMarkdown')
+    .addItem('Export Formulas (XML)', 'exportFormulasXML')
+    .addItem('Export All Data (XML)', 'exportGeneralXML')
     .addToUi();
 }
 
 /**
- * Exports the selected range values as JSON to clipboard
+ * Exports the selected range as row-based Markdown-KV format
  */
-function exportValuesJSON() {
+function exportRowBasedMarkdown() {
   const range = SpreadsheetApp.getActiveRange();
   if (!range) {
     SpreadsheetApp.getUi().alert('Please select a range first.');
     return;
   }
-  
-  const data = buildValuesJSON(range);
-  showClipboardDialog(data, 'Values');
+
+  const data = buildRowBasedMarkdown(range);
+  showClipboardDialog(data, 'Row-based Data');
 }
 
 /**
- * Exports the selected range formulas as JSON to clipboard
+ * Exports the selected range as column-based Markdown-KV format
  */
-function exportFormulasJSON() {
+function exportColumnBasedMarkdown() {
   const range = SpreadsheetApp.getActiveRange();
   if (!range) {
     SpreadsheetApp.getUi().alert('Please select a range first.');
     return;
   }
-  
-  const data = buildFormulasJSON(range);
-  showClipboardDialog(data, 'Formulas');
+
+  const data = buildColumnBasedMarkdown(range);
+  showClipboardDialog(data, 'Column-based Data');
 }
 
 /**
- * Exports both values and formulas for the selected range as JSON to clipboard
+ * Exports the selected range formulas as XML
  */
-function exportBothJSON() {
+function exportFormulasXML() {
   const range = SpreadsheetApp.getActiveRange();
   if (!range) {
     SpreadsheetApp.getUi().alert('Please select a range first.');
     return;
   }
-  
-  const data = buildCombinedJSON(range);
-  showClipboardDialog(data, 'Values and Formulas');
+
+  const data = buildFormulasXML(range);
+  showClipboardDialog(data, 'Formulas (XML)');
 }
 
 /**
- * Builds JSON structure for values only
- * @param {Range} range - The active range
- * @return {string} JSON string
+ * Exports the selected range values as general XML
  */
-function buildValuesJSON(range) {
-  const sheet = range.getSheet();
+function exportGeneralXML() {
+  const range = SpreadsheetApp.getActiveRange();
+  if (!range) {
+    SpreadsheetApp.getUi().alert('Please select a range first.');
+    return;
+  }
+
+  const data = buildGeneralXML(range);
+  showClipboardDialog(data, 'All Data (XML)');
+}
+
+/**
+ * Helper: Extract range metadata
+ */
+function getRangeMeta(range) {
+  return {
+    sheetName: range.getSheet().getName(),
+    rangeNotation: range.getA1Notation(),
+    startRow: range.getRow(),
+    startCol: range.getColumn(),
+    numRows: range.getNumRows(),
+    numCols: range.getNumColumns(),
+    totalCells: range.getNumRows() * range.getNumColumns(),
+    timestamp: new Date().toISOString()
+  };
+}
+
+/**
+ * Helper: Convert column number to letter (1=A, 27=AA)
+ */
+function columnToLetter(col) {
+  let letter = '';
+  while (col > 0) {
+    const remainder = (col - 1) % 26;
+    letter = String.fromCharCode(65 + remainder) + letter;
+    col = Math.floor((col - 1) / 26);
+  }
+  return letter;
+}
+
+/**
+ * Helper: Get absolute A1 notation for a cell
+ */
+function getCellA1Notation(startRow, startCol, row, col) {
+  const absoluteRow = startRow + row - 1;
+  const absoluteCol = startCol + col - 1;
+  return columnToLetter(absoluteCol) + absoluteRow;
+}
+
+/**
+ * Helper: Get relative INDEX notation
+ */
+function getRelativeNotation(row, col) {
+  return 'INDEX(' + row + ',' + col + ')';
+}
+
+/**
+ * Helper: Get row header (first column value)
+ */
+function getRowHeader(values, row) {
+  return values[row - 1] ? values[row - 1][0] : '';
+}
+
+/**
+ * Helper: Get column header (first row value)
+ */
+function getColHeader(values, col) {
+  return values[0] ? values[0][col - 1] : '';
+}
+
+/**
+ * Helper: Calculate absolute row number
+ */
+function getAbsoluteRowNumber(startRow, relativeRow) {
+  return startRow + relativeRow - 1;
+}
+
+/**
+ * Helper: Calculate absolute column letter
+ */
+function getAbsoluteColumnLetter(startCol, relativeCol) {
+  return columnToLetter(startCol + relativeCol - 1);
+}
+
+/**
+ * Helper: Escape XML special characters
+ */
+function escapeXML(text) {
+  if (typeof text !== 'string') {
+    text = String(text);
+  }
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+/**
+ * Helper: Escape Markdown special characters
+ */
+function escapeMarkdown(text) {
+  if (typeof text !== 'string') {
+    text = String(text);
+  }
+  return text
+    .replace(/\\/g, '\\\\')
+    .replace(/\*/g, '\\*')
+    .replace(/_/g, '\\_')
+    .replace(/\[/g, '\\[')
+    .replace(/\]/g, '\\]');
+}
+
+/**
+ * Helper: Check if cell is empty
+ */
+function isEmptyCell(value) {
+  return value === null || value === undefined || value === '';
+}
+
+/**
+ * Build row-based Markdown-KV format
+ */
+function buildRowBasedMarkdown(range) {
+  const meta = getRangeMeta(range);
   const values = range.getValues();
-  
-  const output = {
-    metadata: {
-      sheetName: sheet.getName(),
-      range: range.getA1Notation(),
-      dimensions: {
-        rows: range.getNumRows(),
-        columns: range.getNumColumns()
-      },
-      exportedAt: new Date().toISOString(),
-      exportType: 'values'
-    },
-    data: values
-  };
-  
-  return JSON.stringify(output, null, 2);
+
+  let output = '---\n';
+  output += 'Sheet: ' + meta.sheetName + '\n';
+  output += 'Range: ' + meta.rangeNotation + '\n';
+  output += 'Selection: ' + meta.numRows + ' rows × ' + meta.numCols + ' columns (' + meta.totalCells + ' cells)\n';
+
+  const headerValues = [];
+  for (let col = 0; col < meta.numCols; col++) {
+    headerValues.push(values[0][col]);
+  }
+  output += 'Headers: ' + headerValues.join(', ') + '\n';
+  output += 'Export Type: Row-based (Markdown-KV)\n';
+  output += 'Timestamp: ' + meta.timestamp + '\n';
+  output += 'Note: First row treated as headers. Each subsequent row is a record.\n';
+  output += '---\n\n';
+
+  for (let row = 2; row <= meta.numRows; row++) {
+    const absRowNum = getAbsoluteRowNumber(meta.startRow, row);
+    const rowRange = 'A' + absRowNum + ':' + columnToLetter(meta.startCol + meta.numCols - 1) + absRowNum;
+    const startRowRange = getCellA1Notation(meta.startRow, meta.startCol, row, 1);
+    const endRowRange = getCellA1Notation(meta.startRow, meta.startCol, row, meta.numCols);
+    const actualRange = startRowRange.match(/[A-Z]+/)[0] + absRowNum + ':' + endRowRange.match(/[A-Z]+/)[0] + absRowNum;
+
+    output += '## Row ' + row + ' (Sheet Row ' + absRowNum + ') [' + actualRange + ']\n\n';
+
+    for (let col = 1; col <= meta.numCols; col++) {
+      const header = values[0][col - 1];
+      const cellValue = values[row - 1][col - 1];
+      const absRef = getCellA1Notation(meta.startRow, meta.startCol, row, col);
+      const relRef = getRelativeNotation(row, col);
+
+      const displayValue = isEmptyCell(cellValue) ? '' : cellValue;
+      output += '**' + escapeMarkdown(String(header)) + '** [' + absRef + ', ' + relRef + ']: ' + escapeMarkdown(String(displayValue)) + '\n';
+    }
+    output += '\n';
+  }
+
+  return output;
 }
 
 /**
- * Builds JSON structure for formulas only
- * @param {Range} range - The active range
- * @return {string} JSON string
+ * Build column-based Markdown-KV format
  */
-function buildFormulasJSON(range) {
-  const sheet = range.getSheet();
-  const formulas = range.getFormulas();
-  
-  const output = {
-    metadata: {
-      sheetName: sheet.getName(),
-      range: range.getA1Notation(),
-      dimensions: {
-        rows: range.getNumRows(),
-        columns: range.getNumColumns()
-      },
-      exportedAt: new Date().toISOString(),
-      exportType: 'formulas'
-    },
-    data: formulas
-  };
-  
-  return JSON.stringify(output, null, 2);
+function buildColumnBasedMarkdown(range) {
+  const meta = getRangeMeta(range);
+  const values = range.getValues();
+
+  let output = '---\n';
+  output += 'Sheet: ' + meta.sheetName + '\n';
+  output += 'Range: ' + meta.rangeNotation + '\n';
+  output += 'Selection: ' + meta.numRows + ' rows × ' + meta.numCols + ' columns (' + meta.totalCells + ' cells)\n';
+
+  const headerValues = [];
+  for (let row = 0; row < meta.numRows; row++) {
+    headerValues.push(values[row][0]);
+  }
+  output += 'Headers: ' + headerValues.join(', ') + '\n';
+  output += 'Export Type: Column-based (Markdown-KV)\n';
+  output += 'Timestamp: ' + meta.timestamp + '\n';
+  output += 'Note: First column treated as headers. Each subsequent column is a record.\n';
+  output += '---\n\n';
+
+  for (let col = 2; col <= meta.numCols; col++) {
+    const absColLetter = getAbsoluteColumnLetter(meta.startCol, col);
+    const headerValue = values[0][col - 1];
+    const colStartRow = meta.startRow;
+    const colEndRow = meta.startRow + meta.numRows - 1;
+    const actualRange = absColLetter + colStartRow + ':' + absColLetter + colEndRow;
+
+    output += '## Column ' + col + ' (Sheet Column ' + absColLetter + '): ' + escapeMarkdown(String(headerValue)) + ' [' + actualRange + ']\n\n';
+
+    for (let row = 1; row <= meta.numRows; row++) {
+      const header = values[row - 1][0];
+      const cellValue = values[row - 1][col - 1];
+      const absRef = getCellA1Notation(meta.startRow, meta.startCol, row, col);
+      const relRef = getRelativeNotation(row, col);
+
+      const displayValue = isEmptyCell(cellValue) ? '' : cellValue;
+      output += '**' + escapeMarkdown(String(header)) + '** [' + absRef + ', ' + relRef + ']: ' + escapeMarkdown(String(displayValue)) + '\n';
+    }
+    output += '\n';
+  }
+
+  return output;
 }
 
 /**
- * Builds JSON structure for both values and formulas
- * @param {Range} range - The active range
- * @return {string} JSON string
+ * Build formula XML format
  */
-function buildCombinedJSON(range) {
-  const sheet = range.getSheet();
+function buildFormulasXML(range) {
+  const meta = getRangeMeta(range);
   const values = range.getValues();
   const formulas = range.getFormulas();
-  
-  const output = {
-    metadata: {
-      sheetName: sheet.getName(),
-      range: range.getA1Notation(),
-      dimensions: {
-        rows: range.getNumRows(),
-        columns: range.getNumColumns()
-      },
-      exportedAt: new Date().toISOString(),
-      exportType: 'combined'
-    },
-    values: values,
-    formulas: formulas
-  };
-  
-  return JSON.stringify(output, null, 2);
+
+  let output = '<?xml version="1.0" encoding="UTF-8"?>\n';
+  output += '<!--\n';
+  output += 'Sheet: ' + meta.sheetName + '\n';
+  output += 'Range: ' + meta.rangeNotation + '\n';
+  output += 'Selection: ' + meta.numRows + ' rows × ' + meta.numCols + ' columns (' + meta.totalCells + ' cells)\n';
+
+  let formulaCount = 0;
+  for (let row = 0; row < meta.numRows; row++) {
+    for (let col = 0; col < meta.numCols; col++) {
+      if (!isEmptyCell(formulas[row][col])) {
+        formulaCount++;
+      }
+    }
+  }
+
+  output += 'Formula Cells: ' + formulaCount + ' (' + (meta.totalCells - formulaCount) + ' empty/value-only cells excluded)\n';
+  output += 'Export Type: Formula-only (XML)\n';
+  output += 'Timestamp: ' + meta.timestamp + '\n';
+  output += '\n';
+  output += 'IMPORTANT: This export includes ONLY cells containing formulas.\n';
+  output += 'Empty cells and cells with static values are excluded.\n';
+  output += '-->\n\n';
+  output += '<formulas>\n';
+
+  for (let row = 1; row <= meta.numRows; row++) {
+    for (let col = 1; col <= meta.numCols; col++) {
+      const formula = formulas[row - 1][col - 1];
+      if (!isEmptyCell(formula)) {
+        const absRef = getCellA1Notation(meta.startRow, meta.startCol, row, col);
+        const relRef = getRelativeNotation(row, col);
+        const rowNum = row;
+        const colNum = col;
+
+        output += '  <cell abs="' + absRef + '" rel="' + relRef + '" row="' + rowNum + '" col="' + colNum + '">\n';
+        output += '    <formula>' + escapeXML(formula) + '</formula>\n';
+
+        const rowHeader = values[0] ? values[0][col - 1] : null;
+        const colHeader = values[row - 1] ? values[row - 1][0] : null;
+
+        if (!isEmptyCell(rowHeader) || !isEmptyCell(colHeader)) {
+          output += '    <context>\n';
+          if (!isEmptyCell(rowHeader)) {
+            output += '      <rowHeader>' + escapeXML(String(rowHeader)) + '</rowHeader>\n';
+          }
+          if (!isEmptyCell(colHeader)) {
+            output += '      <colHeader>' + escapeXML(String(colHeader)) + '</colHeader>\n';
+          }
+          output += '    </context>\n';
+        }
+
+        output += '  </cell>\n';
+      }
+    }
+  }
+
+  output += '</formulas>\n';
+  return output;
 }
 
 /**
- * Shows a dialog that copies the JSON data to clipboard
- * @param {string} jsonData - The JSON data to copy
- * @param {string} dataType - Description of what type of data is being copied
+ * Build general XML format (values only)
  */
-function showClipboardDialog(jsonData, dataType) {
+function buildGeneralXML(range) {
+  const meta = getRangeMeta(range);
+  const values = range.getValues();
+
+  let nonEmptyCount = 0;
+  for (let row = 0; row < meta.numRows; row++) {
+    for (let col = 0; col < meta.numCols; col++) {
+      if (!isEmptyCell(values[row][col])) {
+        nonEmptyCount++;
+      }
+    }
+  }
+
+  let output = '<?xml version="1.0" encoding="UTF-8"?>\n';
+  output += '<!--\n';
+  output += 'Sheet: ' + meta.sheetName + '\n';
+  output += 'Range: ' + meta.rangeNotation + '\n';
+  output += 'Selection: ' + meta.numRows + ' rows × ' + meta.numCols + ' columns (' + meta.totalCells + ' cells)\n';
+  output += 'Non-Empty Cells: ' + nonEmptyCount + ' (' + (meta.totalCells - nonEmptyCount) + ' empty cells excluded)\n';
+  output += 'Export Type: General (XML, values only)\n';
+  output += 'Timestamp: ' + meta.timestamp + '\n';
+  output += '\n';
+  output += 'IMPORTANT: This export includes cell VALUES only (formulas are evaluated).\n';
+  output += 'Empty cells are excluded to optimize token usage.\n';
+  output += '-->\n\n';
+  output += '<data>\n';
+
+  for (let row = 1; row <= meta.numRows; row++) {
+    for (let col = 1; col <= meta.numCols; col++) {
+      const cellValue = values[row - 1][col - 1];
+      if (!isEmptyCell(cellValue)) {
+        const absRef = getCellA1Notation(meta.startRow, meta.startCol, row, col);
+        const relRef = getRelativeNotation(row, col);
+
+        output += '  <cell abs="' + absRef + '" rel="' + relRef + '" row="' + row + '" col="' + col + '">\n';
+        output += '    <value>' + escapeXML(String(cellValue)) + '</value>\n';
+        output += '  </cell>\n';
+      }
+    }
+  }
+
+  output += '</data>\n';
+  return output;
+}
+
+/**
+ * Shows a dialog that displays data for copying to clipboard
+ */
+function showClipboardDialog(data, dataType) {
   const htmlTemplate = HtmlService.createTemplateFromFile('ClipboardDialog');
-  htmlTemplate.jsonData = jsonData;
+  htmlTemplate.jsonData = data;
   htmlTemplate.dataType = dataType;
-  
+
   const html = htmlTemplate.evaluate()
     .setWidth(500)
-    .setHeight(300);
-  
-  SpreadsheetApp.getUi().showModalDialog(html, 'Export to JSON');
+    .setHeight(400);
+
+  SpreadsheetApp.getUi().showModalDialog(html, 'Export Data');
 }


### PR DESCRIPTION
## Summary

Completely revamps Sheet Snip's export functionality from JSON to LLM-optimized formats (Markdown-KV and XML).

### What Changed

- **Export Rows (Markdown)**: New row-based Markdown-KV format where each row after the header becomes a record
- **Export Columns (Markdown)**: New column-based Markdown-KV format where each column after the first becomes a record
- **Export Formulas (XML)**: New formula-only XML export showing only cells with formulas, with context tags
- **Export All Data (XML)**: New general-purpose XML value dump with all non-empty cells

All formats include:
- Rich metadata frontmatter (sheet name, range, dimensions, timestamp)
- Both absolute (A1 notation) and relative (INDEX notation) cell references
- Token-efficient design for Claude comprehension
- Escaped content for safe serialization

### Implementation Details

**Code Changes:**
- Replaced all JSON export functions with 4 new builder functions
- Added 11 helper functions for cell references, escaping, and metadata
- Updated menu to show 4 new export options
- Updated dialog for larger preview (250px height) and removed JSON references

**Format Examples:**

Row-based Markdown:
\`\`\`markdown
---
Sheet: Sales Data
Range: B3:E7
Export Type: Row-based (Markdown-KV)
...
---

## Row 2 (Sheet Row 4) [B4:E4]

**Product** [B4, INDEX(1,1)]: Widget A
**Q1 Sales** [C4, INDEX(1,2)]: 1250
\`\`\`

Formula XML:
\`\`\`xml
<?xml version="1.0" encoding="UTF-8"?>
<\!--
Formula Cells: 12 (28 empty/value-only cells excluded)
...
-->
<formulas>
  <cell abs="D2" rel="INDEX(2,4)" row="2" col="4">
    <formula>=SUM(B2:C2)</formula>
    <context>
      <rowHeader>Product A</rowHeader>
      <colHeader>Total</colHeader>
    </context>
  </cell>
</formulas>
\`\`\`

### Testing Plan

- [ ] Test row-based export with standard tabular data
- [ ] Test column-based export with time-series data
- [ ] Test formula export with mixed formula/value cells
- [ ] Test general XML with sparse data
- [ ] Verify empty cell handling per spec
- [ ] Verify cell reference accuracy (absolute and relative)
- [ ] Test special character escaping
- [ ] Verify clipboard copy functionality

### Breaking Changes

- Complete replacement of JSON export formats
- Menu items changed from "Copy Values (JSON)" etc. to "Export Rows (Markdown)" etc.
- No backward compatibility (acceptable for early-stage add-on pre-marketplace)

Closes #5

Generated with Claude Code