### PR TITLE
Implement keyboard accessibility improvements for ClipboardDialog

### DIFF
--- a/src/ClipboardDialog.html
+++ b/src/ClipboardDialog.html
@@ -50,6 +50,12 @@
         resize: vertical;
       }
 
+      .preview:focus {
+        outline: 2px solid #4285f4;
+        outline-offset: -1px;
+        border-color: #4285f4;
+      }
+
       .button-container {
         display: flex;
         gap: 8px;
@@ -113,14 +119,14 @@
       </div>
 
       <div class="preview-container">
-        <textarea class="preview" id="dataPreview" readonly><?= exportData ?></textarea>
+        <textarea class="preview" id="dataPreview" tabindex="1" readonly><?= exportData ?></textarea>
       </div>
 
       <div class="button-container">
-        <button class="copy-button" id="copyButton" onclick="copyToClipboard()">
+        <button class="copy-button" id="copyButton" tabindex="2" onclick="copyToClipboard()">
           Copy to Clipboard
         </button>
-        <button class="close-button" onclick="closeSidebar()">
+        <button class="close-button" tabindex="3" onclick="closeSidebar()">
           Close
         </button>
       </div>


### PR DESCRIPTION
## Summary
- Add tabindex attributes to all interactive elements for proper keyboard navigation
- Implement focus styles for textarea element with blue outline indicator
- Establish logical tab order: preview textarea (1) → copy button (2) → close button (3)
- Follows Google's accessibility best practices for Google Workspace add-ons

## Changes Made
- **tabindex attributes**: Added explicit tab indices to ensure predictable keyboard navigation order
  - Textarea: tabindex="1" (allows users to review data before copying)
  - Copy button: tabindex="2" (primary action)
  - Close button: tabindex="3" (secondary action)
- **Focus styles**: Enhanced .preview:focus with 2px blue outline and border color change for visual feedback

## Keyboard Accessibility Features
- Tab navigation works logically through all focusable elements
- Existing keyboard shortcuts still work: Enter/Ctrl+C to copy, Esc to close
- Copy button auto-focuses on dialog load for immediate keyboard access
- All interactive elements have clear visual focus indicators

## Test Plan
- Test Tab key navigation cycles through: preview → copy button → close button
- Verify Shift+Tab navigation works in reverse order
- Confirm Enter key triggers copy when copy button is focused
- Verify Escape key closes the dialog from any focused element
- Check that focus indicators are clearly visible in all states